### PR TITLE
Generate synthons for both sides of bifunctional building block

### DIFF
--- a/src/SyntOn_BBs.py
+++ b/src/SyntOn_BBs.py
@@ -246,8 +246,11 @@ def __synthonsAssignement(CurrentClass, PreviousClasses, molSmi, MarksSetup, kee
                                           firstReactionAsPrep, func, PreviousClasses, CurrentClass, twoPGs)
 
     elif firstReactionAsPrep:
-        synthons = __FirstReactionAsPrep(MarksSetup[CurrentClass]['Labels'], MarksSetup[CurrentClass]['SMARTS'],
-                                        PreviousClasses, CurrentClass, mol, func)
+        synthons = __NormalSynthonsGenerator(MarksSetup[CurrentClass]['Labels'], MarksSetup[CurrentClass]['SMARTS'],
+                                             PreviousClasses, CurrentClass, mol,
+                                             func=func)
+        synthons.update(__FirstReactionAsPrep(MarksSetup[CurrentClass]['Labels'], MarksSetup[CurrentClass]['SMARTS'],
+                                              PreviousClasses, CurrentClass, mol, func))
     else:
         synthons = __NormalSynthonsGenerator(MarksSetup[CurrentClass]['Labels'], MarksSetup[CurrentClass]['SMARTS'],
                                            PreviousClasses, CurrentClass, mol,


### PR DESCRIPTION
When generating synthons for Aldehyde_ArylHalides the aldehyde labels are applied first and so the synthon needed to generate this reaction scheme is not generated. This PR generates synthons for both halves of the bifunctional building block.

![Sonogashira](https://user-images.githubusercontent.com/17167349/162051325-1505a23a-2a3c-4d74-9d3d-066b00d89de9.png)

